### PR TITLE
Add a default, read-only database for quick deploying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
 RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
 
 # Install java
+RUN apt-get update 
 RUN apt-get install oracle-java8-installer -y --no-install-recommends
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 

--- a/params.env
+++ b/params.env
@@ -1,6 +1,6 @@
-PGSQL_HOST=134.96.104.204
-PGSQL_DATABASE=acl_anthology
-PGSQL_USER=postgres
-PGSQL_PASS=postgres
+PGSQL_HOST=195.201.121.188
+PGSQL_DATABASE=db_acl
+PGSQL_USER=read_only
+PGSQL_PASS=i_will_be_good_i_promise
 PDF_SERVER=http://acl-arc.comp.nus.edu.sg/archives/acl-arc-160301-pdf/files.txt
 POPULATE_DB=false

--- a/startup.sh
+++ b/startup.sh
@@ -34,6 +34,7 @@ sed -i "60c\
 # create the database
 if ${POPULATE_DB}
 then
+	echo "Populating db"
 	rake db:drop
 	rake db:create
 	rake db:migrate
@@ -46,6 +47,8 @@ then
 fi
 
 # Start the services
+cd /home/acl
+RAILS_ENV=production bundle exec rake assets:precompile
 cd /home/acl/jetty
 java -jar start.jar &
 rake acl:reindex_solr


### PR DESCRIPTION
This pull request fixes one bug, and adds a feature. Apologies for bundling two unrelated issues in one pull request.

### The bug
There's a step missing in the ``startup.sh`` script that prevents RoR's internal web server from rendering images correctly. I've added this step now - essentially, the line ``RAILS_ENV=production bundle exec rake assets:precompile``.

### The feature
By default, this Docker image provides no database. This is intended: we expect all mirrors to host their own database, should anything happen to the official ACL mirror. This also means that running the image for the first time will require a couple hours of precompilation or an already-populated database.

In order to simplify onboarding, I've set up a small, read-only database server and changed the defaults to point to this server. In this way, anyone can start a Docker image right now, and gradually reconfigure their instance to use their own database.