### PR TITLE
Fix a bug that prevented images from being displayed on the web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Security advice: the user PGSQL_USER needs write access to PGSQL_DATABASE.
 We encourage you to create a restricted user with no access to any other
 database in the same host.
 
+The default configuration options connect this Docker image to a read-only
+remote database. This database is provided only to simplify the initial setup,
+but you should not rely on it. We strongly encourage you to set your own local
+database server, and update your configuration.
 
 ## Step 2: allocate data resources
 

--- a/params.env
+++ b/params.env
@@ -1,6 +1,6 @@
-PGSQL_HOST=134.96.104.204
-PGSQL_DATABASE=acl_anthology
-PGSQL_USER=postgres
-PGSQL_PASS=postgres
+PGSQL_HOST=195.201.121.188
+PGSQL_DATABASE=db_acl
+PGSQL_USER=read_only
+PGSQL_PASS=i_will_be_good_i_promise
 PDF_SERVER=http://acl-arc.comp.nus.edu.sg/archives/acl-arc-160301-pdf/files.txt
 POPULATE_DB=false

--- a/startup.sh
+++ b/startup.sh
@@ -45,6 +45,10 @@ then
 	done > /dev/null
 fi
 
+# Compile assets
+cd /home/acl
+RAILS_ENV=production bundle exec rake assets:precompile
+
 # Start the services
 cd /home/acl/jetty
 java -jar start.jar &


### PR DESCRIPTION
There's a command missing from the startup script that prevents most images from being shown. This pull request adds that command.